### PR TITLE
Fix compatibility with subdirectory installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
     - WP_VERSION=*
 
 php:
+  - 7.4
   - 7.3
   - 7.2
-  - 7.1
   - 5.6
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ php:
 matrix:
   include:
     - php: 7.2
-      env: WP_VERSION=4.8.0
+      env: TEST_SUBDIRECTORY_INSTALL=1
     - php: 5.6
       env: WP_VERSION=4.4.0
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -27,18 +27,72 @@ function get_hash($src)
  */
 function get_local_path($src)
 {
+    // Local srcs are either relative or use the local domain.
     if (! is_relative_url($src) && ! is_local_domain($src)) {
         return false;
     }
 
-    $web_root  = apply_filters('version_assets/web_root', dirname(WP_CONTENT_DIR));
-    $file_path = path_join($web_root, ltrim(parse_url($src, PHP_URL_PATH), '/\\'));
+    // Core assets are all registered relative to ABSPATH,
+    // so we must rewrite the src if this is not the same as the web root to get the correct path.
+    if (is_core_src($src)) {
+        $src = rewrite_core_src($src);
+    }
+
+    $file_path = path_join(guess_web_root(), ltrim(parse_url($src, PHP_URL_PATH), '/\\'));
 
     if (realpath($file_path)) {
         return $file_path;
     }
 
     return false;
+}
+
+/**
+ * Get the absolute path to the web root directory.
+ *
+ * The web root is inferred as the parent of the content directory by default.
+ *
+ * @return string
+ */
+function guess_web_root() {
+    /**
+     * Filter the path used for the web root.
+     */
+    $path = apply_filters('version_assets/web_root', dirname(WP_CONTENT_DIR));
+
+    return untrailingslashit($path);
+}
+
+/**
+ * Checks if the given src is for a core asset.
+ *
+ * @param string $src Asset src to check.
+ *
+ * @return bool
+ */
+function is_core_src($src) {
+    return (
+        // Core assets are all registered using relative srcs, from ABSPATH (not web root).
+        is_relative_url($src)
+        // Only rewrite the src if core is not installed in the web root.
+        && guess_web_root() !== untrailingslashit(ABSPATH)
+        // Check that the src is for a core asset.
+        && preg_match('#^/wp-(admin|includes)/#', $src)
+    );
+}
+
+/**
+ * Rewrites a core src to be relative to the web root.
+ *
+ * @param string $src Asset src to rewrite.
+ *
+ * @return string
+ */
+function rewrite_core_src($src) {
+    $preg_quoted_web_root = preg_quote(guess_web_root(), '#');
+    $wordpress_path = preg_replace("#^$preg_quoted_web_root#", '', untrailingslashit(ABSPATH));
+
+    return path_join($wordpress_path, ltrim($src, '/'));
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -32,67 +32,27 @@ function get_local_path($src)
         return false;
     }
 
-    // Core assets are all registered relative to ABSPATH,
-    // so we must rewrite the src if this is not the same as the web root to get the correct path.
-    if (is_core_src($src)) {
-        $src = rewrite_core_src($src);
+    /**
+     * Filter the path used for the web root.
+     */
+    $web_root = apply_filters('version_assets/web_root', dirname(WP_CONTENT_DIR));
+    $web_root = untrailingslashit($web_root);
+
+    // Core assets are all registered using relative srcs, from ABSPATH (not web root),
+    // so we must rewrite the src if ABSPATH is not the same as the web root to get the correct path.
+    if (preg_match('#^/wp-(admin|includes)/#', $src) && $web_root !== untrailingslashit(ABSPATH)) {
+        $preg_quoted_web_root = preg_quote($web_root, '#');
+        $wordpress_path = preg_replace("#^$preg_quoted_web_root#", '', untrailingslashit(ABSPATH));
+        $src = path_join($wordpress_path, ltrim($src, '/'));
     }
 
-    $file_path = path_join(guess_web_root(), ltrim(parse_url($src, PHP_URL_PATH), '/\\'));
+    $file_path = path_join($web_root, ltrim(parse_url($src, PHP_URL_PATH), '/\\'));
 
     if (realpath($file_path)) {
         return $file_path;
     }
 
     return false;
-}
-
-/**
- * Get the absolute path to the web root directory.
- *
- * The web root is inferred as the parent of the content directory by default.
- *
- * @return string
- */
-function guess_web_root() {
-    /**
-     * Filter the path used for the web root.
-     */
-    $path = apply_filters('version_assets/web_root', dirname(WP_CONTENT_DIR));
-
-    return untrailingslashit($path);
-}
-
-/**
- * Checks if the given src is for a core asset.
- *
- * @param string $src Asset src to check.
- *
- * @return bool
- */
-function is_core_src($src) {
-    return (
-        // Core assets are all registered using relative srcs, from ABSPATH (not web root).
-        is_relative_url($src)
-        // Only rewrite the src if core is not installed in the web root.
-        && guess_web_root() !== untrailingslashit(ABSPATH)
-        // Check that the src is for a core asset.
-        && preg_match('#^/wp-(admin|includes)/#', $src)
-    );
-}
-
-/**
- * Rewrites a core src to be relative to the web root.
- *
- * @param string $src Asset src to rewrite.
- *
- * @return string
- */
-function rewrite_core_src($src) {
-    $preg_quoted_web_root = preg_quote(guess_web_root(), '#');
-    $wordpress_path = preg_replace("#^$preg_quoted_web_root#", '', untrailingslashit(ABSPATH));
-
-    return path_join($wordpress_path, ltrim($src, '/'));
 }
 
 /**

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -37,10 +37,11 @@ class FunctionsTest extends \WP_UnitTestCase
     function local_path_provider()
     {
         return [
+            // Core registers its assets using relative paths, regardless of subdirectory or not.
+            ['/wp-admin/css/common.css', ABSPATH . 'wp-admin/css/common.css'],
             ['/wp-admin/css/about.css', ABSPATH . 'wp-admin/css/about.css'],
             [admin_url('css/about.css'), ABSPATH . 'wp-admin/css/about.css'],
             [admin_url('js/common.js'), ABSPATH . 'wp-admin/js/common.js'],
-            ['wp-includes/js/wp-emoji.js', ABSPATH . 'wp-includes/js/wp-emoji.js'],
         ];
     }
 }

--- a/tests/wp-config.php
+++ b/tests/wp-config.php
@@ -62,3 +62,9 @@ define( 'WP_TESTS_TITLE', 'Test Blog' );
 define( 'WP_PHP_BINARY', 'php' );
 
 define( 'WPLANG', '' );
+
+if ( getenv( 'TEST_SUBDIRECTORY_INSTALL' ) ) {
+    define( 'WP_CONTENT_DIR', dirname( ABSPATH ) . '/content' );
+    define( 'WP_CONTENT_URL', 'http://' . WP_TESTS_DOMAIN . '/content' );
+    define( 'WP_SITEURL', 'http://' . WP_TESTS_DOMAIN . '/wordpress' );
+}


### PR DESCRIPTION
This PR fixes an incompatibility with subdirectory installs (where wordpress is installed as a child of the web root). This caused core versions to not be rewritten with content hashes due to the local path to the core asset failing.