### PR TITLE
Alias support

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -11,7 +11,9 @@ namespace VersionAssets;
  */
 function get_hash($src)
 {
-    if ($file_path = get_local_path($src)) {
+    $file_path = get_local_path($src);
+
+    if ($file_path && is_file($file_path) && is_readable($file_path)) {
         return md5_file($file_path);
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -13,7 +13,7 @@ function get_hash($src)
 {
     $file_path = get_local_path($src);
 
-    if ($file_path && is_file($file_path) && is_readable($file_path)) {
+    if ($file_path && is_readable($file_path)) {
         return md5_file($file_path);
     }
 
@@ -53,9 +53,10 @@ function get_local_path($src)
     }
 
     $file_path = path_join($web_root, ltrim(parse_url($src, PHP_URL_PATH), '/\\'));
+    $real_path = realpath($file_path);
 
-    if (realpath($file_path)) {
-        return $file_path;
+    if ($real_path && is_file($real_path)) {
+        return $real_path;
     }
 
     return false;

--- a/src/functions.php
+++ b/src/functions.php
@@ -27,6 +27,10 @@ function get_hash($src)
  */
 function get_local_path($src)
 {
+    if (! $src) {
+        return false;
+    }
+
     // Local srcs are either relative or use the local domain.
     if (! is_relative_url($src) && ! is_local_domain($src)) {
         return false;

--- a/tests/feature/VersionAssetsTest.php
+++ b/tests/feature/VersionAssetsTest.php
@@ -51,6 +51,20 @@ class VersionAssetsTest extends \WP_UnitTestCase
     }
 
     /** @test */
+    function it_preserves_the_registered_version_if_the_src_is_falsy()
+    {
+        wp_register_style('test-real', WP_CONTENT_URL . '/test.css', [], 'registered-version');
+        // Some assets may have false for their src which is used for aliases (e.g. 'jquery').
+        wp_register_style('test-alias', false, ['test-real'], 'registered-version');
+        wp_enqueue_style('test-alias');
+
+        $url = $this->get_enqueued_url('test-alias');
+        parse_str(parse_url($url, PHP_URL_QUERY), $url_query_params);
+        $this->assertContains('registered-version', $url);
+        $this->assertEquals(['ver' => 'registered-version'], $url_query_params);
+    }
+
+    /** @test */
     function it_replaces_the_global_wp_styles_instance_when_it_is_initialzed()
     {
         $instance = wp_styles();

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -42,6 +42,8 @@ class FunctionsTest extends \WP_UnitTestCase
             ['/wp-admin/css/about.css', ABSPATH . 'wp-admin/css/about.css'],
             [admin_url('css/about.css'), ABSPATH . 'wp-admin/css/about.css'],
             [admin_url('js/common.js'), ABSPATH . 'wp-admin/js/common.js'],
+            // Asset aliases have an src of `false`
+            [false, false],
         ];
     }
 }


### PR DESCRIPTION
This PR fixes an edge case for asset aliases (scripts or styles with an src of `false`) which caused the local path to resolve to a directory, which raised a warning when attempted to be hashed.