### PR TITLE
Add workaround for doingitwrong warning

### DIFF
--- a/version-assets.php
+++ b/version-assets.php
@@ -16,5 +16,14 @@ require_once __DIR__ . '/src/HashifyVersion.php';
 require_once __DIR__ . '/src/Styles.php';
 require_once __DIR__ . '/src/Scripts.php';
 
+/**
+ * Set placeholder WP_Query before initializing Styles and Scripts to avoid
+ * _doing_it_wrong warning triggered since WP 5.8.
+ * @see https://core.trac.wordpress.org/ticket/53848
+ */
+$GLOBALS['wp_query'] = new \WP_Query();
+
 $GLOBALS['wp_styles'] = new Styles();
 $GLOBALS['wp_scripts'] = new Scripts();
+
+unset($GLOBALS['wp_query']);


### PR DESCRIPTION
This PR adds a simple workaround to avoid the `_doing_it_wrong` warning which is raised as a side-effect of instantiating `WP_Styles` since WP 5.8. See https://core.trac.wordpress.org/ticket/53848

The added `WP_Query` does not do anything other than to prevent warning such as "Conditional query tags do not work before the query is run" without running any query. Admittedly a bit of a hack, but it should avoid filling up log files until this is addressed in core.

Fixes #9 